### PR TITLE
fix: preview blanche — boot + assets + env + routes

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,1 +1,1 @@
-export default { extends: ['@commitlint/config-conventional'] };
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   '*.{ts,tsx,js,jsx}': ['eslint --fix', 'prettier --write'],
   '*.{json,md,css,html}': ['prettier --write'],
 };

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
 import App from './App';
 
 describe('App', () => {
   it('renders heading', () => {
-    render(<App />);
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>,
+    );
     expect(
       screen.getByRole('heading', { name: /ComptaPilot/i }),
     ).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,12 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import Home from './Home';
 import NotFound from './NotFound';
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './App';
 import { ErrorBoundary } from './ErrorBoundary';
 import './index.css';
@@ -7,7 +8,11 @@ import './index.css';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/*" element={<App />} />
+        </Routes>
+      </BrowserRouter>
     </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- move router initialization to entry point with catch-all route
- adjust tests and configs for CommonJS to satisfy husky hooks

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b0246b39f08325994cf1dfff1bd64f